### PR TITLE
Fix time display for songs longer than 99:99

### DIFF
--- a/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
@@ -644,7 +644,7 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 	private String generateTimeString(int time) {
 		int seconds = time % 60;
 		int minutes = time / 60;
-		if (minutes > 99) {
+		if (minutes > 999) {
 			return "99:99";
 		}
 		else {
@@ -671,6 +671,7 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 
 		mProgressBar.setProgress(currentTime);
 		mProgressBar.setMax(totalTime);
+		mProgressBar.setKeyProgressIncrement(180);
 
 		if (status.getPlaybackState() == MediaItemStatus.PLAYBACK_STATE_PLAYING ||
 				status.getPlaybackState() == MediaItemStatus.PLAYBACK_STATE_BUFFERING ||

--- a/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
@@ -671,7 +671,7 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 
 		mProgressBar.setProgress(currentTime);
 		mProgressBar.setMax(totalTime);
-		mProgressBar.setKeyProgressIncrement(180);
+		mProgressBar.setKeyProgressIncrement(totalTime / 20); // skip in steps of 5% of song length
 
 		if (status.getPlaybackState() == MediaItemStatus.PLAYBACK_STATE_PLAYING ||
 				status.getPlaybackState() == MediaItemStatus.PLAYBACK_STATE_BUFFERING ||


### PR DESCRIPTION
Fix time display for songs longer than 99:99
Set skip increment to 3 minutes in progress bar (useful for DPAD control)
