### PR TITLE
Added option to play directly on local device

### DIFF
--- a/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
@@ -48,6 +48,7 @@ public class PreferencesActivity extends PreferenceActivity
 
 	public static final String KEY_ENABLE_WIFI_ON_START = "enable_wifi_on_start";
 	public static final String KEY_INCOMING_PHONE_CALL_PAUSE = "incoming_phone_call_pause";
+	public static final String KEY_PLAYBACK_LOCAL_DEVICE = "playback_local_device";
 	private static final String KEY_CONTACT_DEV = "contact_dev";
 
 	private ListPreference mEnableWifiOnStart;

--- a/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
@@ -399,6 +399,12 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 	 * Displays UPNP devices in the ListView.
 	 */
 	private void deviceListMode() {
+		if (PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext())
+				     .getBoolean(PreferencesActivity.KEY_PLAYBACK_LOCAL_DEVICE, false)) {
+			MainActivity activity = (MainActivity) getActivity();
+			activity.mViewPager.setCurrentItem(0);
+			return;
+		}
 		mControls.setVisibility(View.GONE);
 		mListView.setAdapter(mRouteAdapter);
 		disableTrackHighlight();

--- a/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
@@ -256,17 +256,22 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 						break;
 					}
 				}
+
+				if (PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext())
+					.getBoolean(PreferencesActivity.KEY_PLAYBACK_LOCAL_DEVICE, false)) {
+					if ( route.getName().startsWith(getResources().getString(R.string.local_device)) ) {
+						mRouteAdapter.add(route);
+						playlistMode(route);
+					}
+					return;
+				}
+
 				mRouteAdapter.add(route);
 				mRouteAdapter.sort(RouteAdapter.COMPARATOR);
 
 				RouteInfo current = mMediaRouterPlayService.getCurrentRoute();
 				if (current != null && route.getId().equals(current.getId())) {
 					playlistMode(current);
-				} else if ( route.getName().startsWith(getResources().getString(R.string.local_device)) ) {
-					if (PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext())
-						.getBoolean(PreferencesActivity.KEY_PLAYBACK_LOCAL_DEVICE, false)) {
-							playlistMode(route);
-					}
 				}
 			}
 

--- a/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/RouteFragment.java
@@ -37,6 +37,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.support.v7.app.MediaRouteDiscoveryFragment;
 import android.support.v7.media.MediaControlIntent;
 import android.support.v7.media.MediaItemStatus;
@@ -67,6 +68,7 @@ import android.widget.Toast;
 
 import com.github.nutomic.controldlna.R;
 import com.github.nutomic.controldlna.gui.MainActivity.OnBackPressedListener;
+import com.github.nutomic.controldlna.gui.PreferencesActivity;
 import com.github.nutomic.controldlna.mediarouter.MediaRouterPlayService;
 import com.github.nutomic.controldlna.mediarouter.MediaRouterPlayServiceBinder;
 import com.github.nutomic.controldlna.utility.FileArrayAdapter;
@@ -260,6 +262,11 @@ public class RouteFragment extends MediaRouteDiscoveryFragment implements
 				RouteInfo current = mMediaRouterPlayService.getCurrentRoute();
 				if (current != null && route.getId().equals(current.getId())) {
 					playlistMode(current);
+				} else if ( route.getName().startsWith(getResources().getString(R.string.local_device)) ) {
+					if (PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext())
+						.getBoolean(PreferencesActivity.KEY_PLAYBACK_LOCAL_DEVICE, false)) {
+							playlistMode(route);
+					}
 				}
 			}
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
 	<!-- Title for the pause playback on call preference -->
 	<string name="incoming_phone_call_pause">Pause playback on incoming phone call</string>
 	
+	<!-- Title for the playback local device preference -->
+	<string name="playback_local_device">Play directly on local device</string>
+	
 	<!-- Title for the contact developer preference -->
 	<string name="contact_dev_title">Contact Developer</string>
 

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -13,6 +13,11 @@
 			android:title="@string/incoming_phone_call_pause"
 			android:defaultValue="true" />
 
+	<CheckBoxPreference
+			android:key="playback_local_device"
+			android:title="@string/playback_local_device"
+			android:defaultValue="false" />
+
 	<Preference
 			android:key="contact_dev"
 			android:title="@string/contact_dev_title" />


### PR DESCRIPTION
Before starting playback the user has to choose a playback device.
If you normally listen to music on your devices, its annoying and creates the risk to pick the wrong devices.
This option automatically chooses the local device for playback and starts playing immediately.
Must be enabled in preferences.
