### PR TITLE
Workaround crash when opening the preferences, fixes #17

### DIFF
--- a/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
@@ -66,7 +66,8 @@ public class PreferencesActivity extends PreferenceActivity
 		// There is currently no way to get ActionBar in PreferenceActivity on pre-honeycomb with
 		// compatibility library, so we'll have to do a version check.
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-			getActionBar().setDisplayHomeAsUpEnabled(true);
+// crashes in Android 7.0:
+//			getActionBar().setDisplayHomeAsUpEnabled(true);
 		}
 
 		PreferenceManager.getDefaultSharedPreferences(this)

--- a/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
+++ b/src/main/java/com/github/nutomic/controldlna/gui/PreferencesActivity.java
@@ -63,12 +63,9 @@ public class PreferencesActivity extends PreferenceActivity
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		// There is currently no way to get ActionBar in PreferenceActivity on pre-honeycomb with
-		// compatibility library, so we'll have to do a version check.
-		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-// crashes in Android 7.0:
-//			getActionBar().setDisplayHomeAsUpEnabled(true);
-		}
+		// Ideally this code should call getActionBar().setDisplayHomeAsUpEnabled(true) but
+		// it isn't possible to do that with the current appcompat library without re-writing
+		// preferences to use fragments
 
 		PreferenceManager.getDefaultSharedPreferences(this)
 				.registerOnSharedPreferenceChangeListener(this);


### PR DESCRIPTION
This is a workaround for a crash when opening the preferences (seen in Android 7.0 on Moto G5)

What are the consequences of not setting `setDisplayHomeAsUpEnabled(true)`?
